### PR TITLE
refactor: avoid unsupported expo ui components on web

### DIFF
--- a/components/ContextMenu.ios.tsx
+++ b/components/ContextMenu.ios.tsx
@@ -1,11 +1,4 @@
-import {
-  Button,
-  ContextMenu,
-  Host,
-  Image,
-  Submenu,
-  Switch,
-} from "@expo/ui/swift-ui";
+import { Button, ContextMenu, Submenu, Host, Image, Switch } from "./swift-ui";
 import * as React from "react";
 import { View } from "react-native";
 

--- a/components/NormalView.ios.tsx
+++ b/components/NormalView.ios.tsx
@@ -1,11 +1,11 @@
 import {
   Host,
   HStack,
+  VStack,
   LinearProgress,
   Slider,
   Text as UIText,
-  VStack,
-} from "@expo/ui/swift-ui";
+} from "./swift-ui";
 import { background, cornerRadius, padding } from "@expo/ui/swift-ui/modifiers";
 import { useState } from "react";
 const fromSadToHappy = [

--- a/components/liquid-glass/AppContext.tsx
+++ b/components/liquid-glass/AppContext.tsx
@@ -1,4 +1,4 @@
-import { ChartDataPoint, ChartType } from "@expo/ui/swift-ui";
+import { ChartDataPoint, ChartType } from "../swift-ui";
 import React, { createContext, ReactNode, useState } from "react";
 import { AppSettings, AppState, Task, UserProfile } from "./types";
 

--- a/components/liquid-glass/ButtonsSection.tsx
+++ b/components/liquid-glass/ButtonsSection.tsx
@@ -1,4 +1,4 @@
-import { Button, Section, VStack } from "@expo/ui/swift-ui";
+import { Button, Section, VStack } from "../swift-ui";
 import React from "react";
 
 export function ButtonsSection() {

--- a/components/liquid-glass/ContextMenuSection.tsx
+++ b/components/liquid-glass/ContextMenuSection.tsx
@@ -2,14 +2,14 @@ import { foregroundColor } from "@expo/ui/swift-ui/modifiers";
 import {
   Button,
   ContextMenu,
+  Submenu,
   Host,
   HStack,
+  VStack,
   Section,
-  Submenu,
   Switch,
   Text,
-  VStack,
-} from "@expo/ui/swift-ui";
+} from "../swift-ui";
 import React, { use } from "react";
 import { AppContext } from "./AppContext";
 import { AppState } from "./types";

--- a/components/liquid-glass/DashboardSection.tsx
+++ b/components/liquid-glass/DashboardSection.tsx
@@ -3,11 +3,11 @@ import {
   Button,
   Gauge,
   HStack,
+  VStack,
   Section,
   Slider,
   Text,
-  VStack,
-} from "@expo/ui/swift-ui";
+} from "../swift-ui";
 import React, { use } from "react";
 import { AppContext } from "./AppContext";
 import { AppState } from "./types";

--- a/components/liquid-glass/DateTimeSection.tsx
+++ b/components/liquid-glass/DateTimeSection.tsx
@@ -1,10 +1,10 @@
 import {
   DateTimePicker,
-  DateTimePickerProps,
+  type DateTimePickerProps,
   Picker,
   Section,
   Text,
-} from "@expo/ui/swift-ui";
+} from "../swift-ui";
 import React, { use, useState } from "react";
 import { AppContext } from "./AppContext";
 import { AppState } from "./types";

--- a/components/liquid-glass/ProfileSection.tsx
+++ b/components/liquid-glass/ProfileSection.tsx
@@ -13,14 +13,13 @@ import {
   Image as ExpoUIImage,
   Group,
   HStack,
-  Image,
+  VStack,
   Picker,
   Section,
   Spacer,
   Switch,
   Text,
-  VStack,
-} from "@expo/ui/swift-ui";
+} from "../swift-ui";
 import { Image as ExpoImage } from "expo-image";
 import { Link } from "expo-router";
 import React, { use, useState } from "react";
@@ -157,7 +156,7 @@ export function ProfileSection() {
           frame({ width: 100, height: 100 }),
         ]}
       >
-        <Image
+        <ExpoUIImage
           systemName="applelogo"
           // onPress={() => alert("This is an image")}
           size={50}

--- a/components/liquid-glass/SettingsSection.tsx
+++ b/components/liquid-glass/SettingsSection.tsx
@@ -1,4 +1,4 @@
-import { DisclosureGroup, Picker, Section, Switch } from "@expo/ui/swift-ui";
+import { DisclosureGroup, Picker, Section, Switch } from "../swift-ui";
 import React, { use, useState } from "react";
 import { AppContext } from "./AppContext";
 import { AppState } from "./types";

--- a/components/liquid-glass/TaskManagementSection.tsx
+++ b/components/liquid-glass/TaskManagementSection.tsx
@@ -2,12 +2,12 @@ import { foregroundColor } from "@expo/ui/swift-ui/modifiers";
 import {
   ContentUnavailableView,
   HStack,
+  VStack,
   Picker,
   Section,
   Switch,
   Text,
-  VStack,
-} from "@expo/ui/swift-ui";
+} from "../swift-ui";
 import React, { use } from "react";
 import { AppContext } from "./AppContext";
 import { AppState } from "./types";

--- a/components/liquid-glass/types.ts
+++ b/components/liquid-glass/types.ts
@@ -1,4 +1,4 @@
-import { ChartDataPoint, ChartType } from "@expo/ui/swift-ui";
+import { ChartDataPoint, ChartType } from "../swift-ui";
 
 // Types
 export interface Task {

--- a/components/screens/basic-usage.tsx
+++ b/components/screens/basic-usage.tsx
@@ -7,13 +7,13 @@ import {
 } from "@expo/ui/swift-ui/modifiers";
 import {
   CircularProgress,
+  LinearProgress,
   Text as ExpoUIText,
   Host,
   HStack,
-  LinearProgress,
   Slider,
   VStack,
-} from "@expo/ui/swift-ui";
+} from "../swift-ui";
 import { Link } from "expo-router";
 import { useState } from "react";
 import { ScrollView, Text } from "react-native";

--- a/components/screens/home.tsx
+++ b/components/screens/home.tsx
@@ -1,4 +1,4 @@
-import { Button as ButtonPrimitive, Host } from "@expo/ui/swift-ui";
+import { Button as ButtonPrimitive, Host } from "../swift-ui";
 import * as React from "react";
 import { ScrollView, StyleProp, View, ViewStyle } from "react-native";
 

--- a/components/screens/liquid-glass-example.tsx
+++ b/components/screens/liquid-glass-example.tsx
@@ -1,4 +1,4 @@
-import { Form, Host } from "@expo/ui/swift-ui";
+import { Form, Host } from "../swift-ui";
 import React from "react";
 
 import { AppProvider } from "../liquid-glass/AppContext";

--- a/components/screens/modifiers.tsx
+++ b/components/screens/modifiers.tsx
@@ -1,4 +1,4 @@
-import { Host, Text } from "@expo/ui/swift-ui";
+import { Host, Text } from "../swift-ui";
 import { glassEffect, padding } from "@expo/ui/swift-ui/modifiers";
 import { MeshGradientView } from "expo-mesh-gradient";
 import { View } from "react-native";

--- a/components/screens/settings.tsx
+++ b/components/screens/settings.tsx
@@ -1,13 +1,13 @@
 import {
   Chart,
-  ChartDataPoint,
-  ChartType,
+  type ChartDataPoint,
+  type ChartType,
+  type LineChartStyle,
+  type PointChartStyle,
+  type PointStyle,
   Host,
-  LineChartStyle,
   Picker,
-  PointChartStyle,
-  PointStyle,
-} from "@expo/ui/swift-ui";
+} from "../swift-ui";
 import React, { useState } from "react";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
 

--- a/components/swift-ui.ts
+++ b/components/swift-ui.ts
@@ -1,0 +1,26 @@
+export { DateTimePicker, type DateTimePickerProps } from '../node_modules/@expo/ui/src/swift-ui/DatePicker';
+export { Picker } from '../node_modules/@expo/ui/src/swift-ui/Picker';
+export { Section } from '../node_modules/@expo/ui/src/swift-ui/Section';
+export { Text } from '../node_modules/@expo/ui/src/swift-ui/Text';
+export { DisclosureGroup } from '../node_modules/@expo/ui/src/swift-ui/DisclosureGroup';
+export { Switch } from '../node_modules/@expo/ui/src/swift-ui/Switch';
+export { Button } from '../node_modules/@expo/ui/src/swift-ui/Button';
+export { ContextMenu, Submenu } from '../node_modules/@expo/ui/src/swift-ui/ContextMenu';
+export { Host } from '../node_modules/@expo/ui/src/swift-ui/Host';
+export { HStack, VStack, Group } from '../node_modules/@expo/ui/src/swift-ui/Layout';
+export { ContentUnavailableView } from '../node_modules/@expo/ui/src/swift-ui/ContentUnavailableView';
+export { ColorPicker } from '../node_modules/@expo/ui/src/swift-ui/ColorPicker';
+export { Image } from '../node_modules/@expo/ui/src/swift-ui/Image';
+export { Spacer } from '../node_modules/@expo/ui/src/swift-ui/Spacer';
+export { Gauge } from '../node_modules/@expo/ui/src/swift-ui/Gauge';
+export { Slider } from '../node_modules/@expo/ui/src/swift-ui/Slider';
+export { CircularProgress, LinearProgress } from '../node_modules/@expo/ui/src/swift-ui/Progress';
+export { Form } from '../node_modules/@expo/ui/src/swift-ui/Form';
+export {
+  Chart,
+  type ChartDataPoint,
+  type ChartType,
+  type LineChartStyle,
+  type PointChartStyle,
+  type PointStyle,
+} from '../node_modules/@expo/ui/src/swift-ui/Chart';

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "expo-ui-playground",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@expo/ui": "~0.2.0-alpha.5",
         "@expo/vector-icons": "^15.0.2",
@@ -45,6 +46,7 @@
         "@types/react": "~19.1.10",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~10.0.0",
+        "patch-package": "^8.0.0",
         "typescript": "~5.9.2"
       }
     },
@@ -4273,6 +4275,13 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -4627,6 +4636,16 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -7410,6 +7429,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -7491,6 +7520,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/fs.realpath": {
@@ -8881,6 +8926,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -8898,6 +8963,29 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -8924,6 +9012,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -10264,6 +10362,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -10372,6 +10480,112 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/patch-package/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/path-exists": {
@@ -12518,6 +12732,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -12835,6 +13062,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -13409,6 +13646,19 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",


### PR DESCRIPTION
## Summary
- wrap expo-ui SwiftUI modules to skip BottomSheet on web
- update imports to use the local wrapper instead of package root

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c808c540f08321b10ef1c501886f65