### PR TITLE
refactor: avoid unsupported expo ui components on web

### DIFF
--- a/components/ContextMenu.ios.tsx
+++ b/components/ContextMenu.ios.tsx
@@ -1,11 +1,4 @@
-import {
-  Button,
-  ContextMenu,
-  Host,
-  Image,
-  Submenu,
-  Switch,
-} from "@expo/ui/swift-ui";
+import { Button, ContextMenu, Submenu, Host, Image, Switch } from "./swift-ui";
 import * as React from "react";
 import { View } from "react-native";
 

--- a/components/NormalView.ios.tsx
+++ b/components/NormalView.ios.tsx
@@ -1,11 +1,11 @@
 import {
   Host,
   HStack,
+  VStack,
   LinearProgress,
   Slider,
   Text as UIText,
-  VStack,
-} from "@expo/ui/swift-ui";
+} from "./swift-ui";
 import { background, cornerRadius, padding } from "@expo/ui/swift-ui/modifiers";
 import { useState } from "react";
 const fromSadToHappy = [

--- a/components/liquid-glass/AppContext.tsx
+++ b/components/liquid-glass/AppContext.tsx
@@ -1,4 +1,4 @@
-import { ChartDataPoint, ChartType } from "@expo/ui/swift-ui";
+import { ChartDataPoint, ChartType } from "../swift-ui";
 import React, { createContext, ReactNode, useState } from "react";
 import { AppSettings, AppState, Task, UserProfile } from "./types";
 

--- a/components/liquid-glass/ButtonsSection.tsx
+++ b/components/liquid-glass/ButtonsSection.tsx
@@ -1,4 +1,4 @@
-import { Button, Section, VStack } from "@expo/ui/swift-ui";
+import { Button, Section, VStack } from "../swift-ui";
 import React from "react";
 
 export function ButtonsSection() {

--- a/components/liquid-glass/ContextMenuSection.tsx
+++ b/components/liquid-glass/ContextMenuSection.tsx
@@ -2,14 +2,14 @@ import { foregroundColor } from "@expo/ui/swift-ui/modifiers";
 import {
   Button,
   ContextMenu,
+  Submenu,
   Host,
   HStack,
+  VStack,
   Section,
-  Submenu,
   Switch,
   Text,
-  VStack,
-} from "@expo/ui/swift-ui";
+} from "../swift-ui";
 import React, { use } from "react";
 import { AppContext } from "./AppContext";
 import { AppState } from "./types";

--- a/components/liquid-glass/DashboardSection.tsx
+++ b/components/liquid-glass/DashboardSection.tsx
@@ -3,11 +3,11 @@ import {
   Button,
   Gauge,
   HStack,
+  VStack,
   Section,
   Slider,
   Text,
-  VStack,
-} from "@expo/ui/swift-ui";
+} from "../swift-ui";
 import React, { use } from "react";
 import { AppContext } from "./AppContext";
 import { AppState } from "./types";

--- a/components/liquid-glass/DateTimeSection.tsx
+++ b/components/liquid-glass/DateTimeSection.tsx
@@ -1,10 +1,10 @@
 import {
   DateTimePicker,
-  DateTimePickerProps,
+  type DateTimePickerProps,
   Picker,
   Section,
   Text,
-} from "@expo/ui/swift-ui";
+} from "../swift-ui";
 import React, { use, useState } from "react";
 import { AppContext } from "./AppContext";
 import { AppState } from "./types";

--- a/components/liquid-glass/ProfileSection.tsx
+++ b/components/liquid-glass/ProfileSection.tsx
@@ -13,14 +13,13 @@ import {
   Image as ExpoUIImage,
   Group,
   HStack,
-  Image,
+  VStack,
   Picker,
   Section,
   Spacer,
   Switch,
   Text,
-  VStack,
-} from "@expo/ui/swift-ui";
+} from "../swift-ui";
 import { Image as ExpoImage } from "expo-image";
 import { Link } from "expo-router";
 import React, { use, useState } from "react";
@@ -157,7 +156,7 @@ export function ProfileSection() {
           frame({ width: 100, height: 100 }),
         ]}
       >
-        <Image
+        <ExpoUIImage
           systemName="applelogo"
           // onPress={() => alert("This is an image")}
           size={50}

--- a/components/liquid-glass/SettingsSection.tsx
+++ b/components/liquid-glass/SettingsSection.tsx
@@ -1,4 +1,4 @@
-import { DisclosureGroup, Picker, Section, Switch } from "@expo/ui/swift-ui";
+import { DisclosureGroup, Picker, Section, Switch } from "../swift-ui";
 import React, { use, useState } from "react";
 import { AppContext } from "./AppContext";
 import { AppState } from "./types";

--- a/components/liquid-glass/TaskManagementSection.tsx
+++ b/components/liquid-glass/TaskManagementSection.tsx
@@ -2,12 +2,12 @@ import { foregroundColor } from "@expo/ui/swift-ui/modifiers";
 import {
   ContentUnavailableView,
   HStack,
+  VStack,
   Picker,
   Section,
   Switch,
   Text,
-  VStack,
-} from "@expo/ui/swift-ui";
+} from "../swift-ui";
 import React, { use } from "react";
 import { AppContext } from "./AppContext";
 import { AppState } from "./types";

--- a/components/liquid-glass/types.ts
+++ b/components/liquid-glass/types.ts
@@ -1,4 +1,4 @@
-import { ChartDataPoint, ChartType } from "@expo/ui/swift-ui";
+import { ChartDataPoint, ChartType } from "../swift-ui";
 
 // Types
 export interface Task {

--- a/components/screens/basic-usage.tsx
+++ b/components/screens/basic-usage.tsx
@@ -7,13 +7,13 @@ import {
 } from "@expo/ui/swift-ui/modifiers";
 import {
   CircularProgress,
+  LinearProgress,
   Text as ExpoUIText,
   Host,
   HStack,
-  LinearProgress,
   Slider,
   VStack,
-} from "@expo/ui/swift-ui";
+} from "../swift-ui";
 import { Link } from "expo-router";
 import { useState } from "react";
 import { ScrollView, Text } from "react-native";

--- a/components/screens/home.tsx
+++ b/components/screens/home.tsx
@@ -1,4 +1,4 @@
-import { Button as ButtonPrimitive, Host } from "@expo/ui/swift-ui";
+import { Button as ButtonPrimitive, Host } from "../swift-ui";
 import * as React from "react";
 import { ScrollView, StyleProp, View, ViewStyle } from "react-native";
 

--- a/components/screens/liquid-glass-example.tsx
+++ b/components/screens/liquid-glass-example.tsx
@@ -1,4 +1,4 @@
-import { Form, Host } from "@expo/ui/swift-ui";
+import { Form, Host } from "../swift-ui";
 import React from "react";
 
 import { AppProvider } from "../liquid-glass/AppContext";

--- a/components/screens/modifiers.tsx
+++ b/components/screens/modifiers.tsx
@@ -1,4 +1,4 @@
-import { Host, Text } from "@expo/ui/swift-ui";
+import { Host, Text } from "../swift-ui";
 import { glassEffect, padding } from "@expo/ui/swift-ui/modifiers";
 import { MeshGradientView } from "expo-mesh-gradient";
 import { View } from "react-native";

--- a/components/screens/settings.tsx
+++ b/components/screens/settings.tsx
@@ -1,13 +1,13 @@
 import {
   Chart,
-  ChartDataPoint,
-  ChartType,
+  type ChartDataPoint,
+  type ChartType,
+  type LineChartStyle,
+  type PointChartStyle,
+  type PointStyle,
   Host,
-  LineChartStyle,
   Picker,
-  PointChartStyle,
-  PointStyle,
-} from "@expo/ui/swift-ui";
+} from "../swift-ui";
 import React, { useState } from "react";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
 

--- a/components/swift-ui.ts
+++ b/components/swift-ui.ts
@@ -1,0 +1,38 @@
+import { Platform, View, Text as RNText } from 'react-native';
+
+const isWeb = Platform.OS === 'web';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const SwiftUI = isWeb ? {} : require('@expo/ui/swift-ui');
+
+export const DateTimePicker = SwiftUI.DateTimePicker ?? (() => null);
+export const Picker = SwiftUI.Picker ?? View;
+export const Section = SwiftUI.Section ?? View;
+export const Text = SwiftUI.Text ?? RNText;
+export const DisclosureGroup = SwiftUI.DisclosureGroup ?? View;
+export const Switch = SwiftUI.Switch ?? View;
+export const Button = SwiftUI.Button ?? View;
+export const ContextMenu = SwiftUI.ContextMenu ?? View;
+export const Submenu = SwiftUI.Submenu ?? View;
+export const Host = SwiftUI.Host ?? View;
+export const HStack = SwiftUI.HStack ?? View;
+export const VStack = SwiftUI.VStack ?? View;
+export const Group = SwiftUI.Group ?? View;
+export const ContentUnavailableView = SwiftUI.ContentUnavailableView ?? View;
+export const ColorPicker = SwiftUI.ColorPicker ?? View;
+export const Image = SwiftUI.Image ?? View;
+export const Spacer = SwiftUI.Spacer ?? View;
+export const Gauge = SwiftUI.Gauge ?? View;
+export const Slider = SwiftUI.Slider ?? View;
+export const CircularProgress = SwiftUI.CircularProgress ?? View;
+export const LinearProgress = SwiftUI.LinearProgress ?? View;
+export const Form = SwiftUI.Form ?? View;
+export const Chart = SwiftUI.Chart ?? View;
+
+export type { DateTimePickerProps } from '@expo/ui/src/swift-ui/DatePicker';
+export type {
+  ChartDataPoint,
+  ChartType,
+  LineChartStyle,
+  PointChartStyle,
+  PointStyle,
+} from '@expo/ui/src/swift-ui/Chart';


### PR DESCRIPTION
## Summary
- guard expo-ui SwiftUI imports with web fallbacks to prevent native view errors on web

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c808c540f08321b10ef1c501886f65